### PR TITLE
Add word count and donut chart

### DIFF
--- a/donut-graph.js
+++ b/donut-graph.js
@@ -3,6 +3,8 @@ $(document).ready(function(){
 	$('#analyze').on('click', function(event){
 		event.preventDefault();
 		createGraph;
+		var body = document.getElementById('text-to-analyze').value
+		wordCount(body);
 	})
 })
 

--- a/index.html
+++ b/index.html
@@ -20,23 +20,33 @@
 			<div class="col-md-6 input">
 				<h2>Type text to be analyzed</h2>
 				<form>
-					<textarea class="form-control" style="min-width: 100%" rows="25"></textarea><br><br>
+					<textarea class="form-control" id="text-to-analyze" style="min-width: 100%" rows="25"></textarea><br><br>
 					<button id="analyze" class="btn btn-primary"><span>Analyze</span></button>
 				</form>
 			</div>
 
 			<div class="col-md-6 analysis">
-				<div class="panel panel-default">
-					<div class="panel-heading">Results</div>
-					<div class="panel-body">Time to Read</div>
-					<div class="panel-body">Sentiment Analysis <br>
+        <h3>Results</h3>
+        <div class="panel panel-default">
+          <div class="panel-heading">Time to Read</div>
+          <div class="panel-body">Here goes the time to read</div>
+        </div>
 
-					</div>
-					<div class="panel-body">Top 3 Words</div>
-					<div class="panel-body">Formality Analysis</div>
-				</div>
+        <br>
+        
+        <div class="panel panel-default">
+          <div class="panel-heading">Sentiment Analysis</div>
+          <div class="panel-body">Here goes the time to read</div>
+        </div>
+
+        <br>
+        
+        <div class="panel panel-default">
+          <div class="panel-heading">Top 3 Words</div>
+          <div class="panel-body" id="top-words"></div>
+        </div>
+
 			</div>
-
 		</div>
 	</div>
 

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
 	<script src = "http://d3js.org/d3.v3.min.js"></script>
 	<script src = "donut-graph.js"></script>
+  <script src = "word_count.js"></script>
 </head>
 <body>
 

--- a/word_count.js
+++ b/word_count.js
@@ -1,4 +1,4 @@
-var body = "Mr. Jones,\nI have been researching our choices for internet providers over the past week, and I wanted to update you on my progress. We have two options: H.C. Cable and Toll South. Both offer business plans, and I will go over the business pricing of each plan at the meeting on Tuesday. Both of the business options I listed have comparable speed and data usage offerings as well. I called your personal provider, GoGo Satellite, but they did not have any business offerings. They primarily do residential internet service.\n I will talk with Joe and Susan in IT about these options and get their suggestions. I will also send out meeting requests to everyone, including Mr. Morris in operations. If you have any questions prior to the meeting, please let me know.\n Respectfully,\nTina McAden\nAdministrative Assistant\nJones Office Solutions\nhttp://www.jonesofficesolutions.com\n(555) 124-5678"
+// var body = "Mr. Jones,\nI have been researching our choices for internet providers over the past week, and I wanted to update you on my progress. We have two options: H.C. Cable and Toll South. Both offer business plans, and I will go over the business pricing of each plan at the meeting on Tuesday. Both of the business options I listed have comparable speed and data usage offerings as well. I called your personal provider, GoGo Satellite, but they did not have any business offerings. They primarily do residential internet service.\n I will talk with Joe and Susan in IT about these options and get their suggestions. I will also send out meeting requests to everyone, including Mr. Morris in operations. If you have any questions prior to the meeting, please let me know.\n Respectfully,\nTina McAden\nAdministrative Assistant\nJones Office Solutions\nhttp://www.jonesofficesolutions.com\n(555) 124-5678"
 
 
 var toRemoveArray = ['and', 'I', 'the' , 'have', 'to', 'will'];
@@ -9,9 +9,8 @@ function wordCount(str){
   var cleanStrArray = removeKeyWords(strArray,toRemoveArray);
   var wordMap = groupByOccurence(cleanStrArray);
   var sortedWords = sortByOccurence(wordMap);
-  console.log(sortedWords);
   var topWords = selectTopWords(sortedWords, 5);
-  console.log(topWords);
+  var topWordsHTML = appendTopWords(topWords);
 }
 
 function removeKeyWords(keepArray,toRemoveArray){
@@ -55,5 +54,13 @@ function selectTopWords(arr, n){
   return topWords
 }
 
+function appendTopWords(topWords){
+  topWordsHTML = ""
 
-wordCount(body);
+  for(var i = 0; i < topWords.length; i++){
+    console.log(topWords[i][0]);
+    topWordsHTML = topWordsHTML.concat("<span class='label label-primary'>" + topWords[i][0] + "</span>" + "<span class='label label-danger'>" + topWords[i][1] + "</span>" + "&nbsp;");
+  }
+
+  $("#top-words").append(topWordsHTML);
+}

--- a/word_count.js
+++ b/word_count.js
@@ -1,0 +1,59 @@
+var body = "Mr. Jones,\nI have been researching our choices for internet providers over the past week, and I wanted to update you on my progress. We have two options: H.C. Cable and Toll South. Both offer business plans, and I will go over the business pricing of each plan at the meeting on Tuesday. Both of the business options I listed have comparable speed and data usage offerings as well. I called your personal provider, GoGo Satellite, but they did not have any business offerings. They primarily do residential internet service.\n I will talk with Joe and Susan in IT about these options and get their suggestions. I will also send out meeting requests to everyone, including Mr. Morris in operations. If you have any questions prior to the meeting, please let me know.\n Respectfully,\nTina McAden\nAdministrative Assistant\nJones Office Solutions\nhttp://www.jonesofficesolutions.com\n(555) 124-5678"
+
+
+var toRemoveArray = ['and', 'I', 'the' , 'have', 'to', 'will'];
+
+
+function wordCount(str){
+  var strArray = str.split(' ');
+  var cleanStrArray = removeKeyWords(strArray,toRemoveArray);
+  var wordMap = groupByOccurence(cleanStrArray);
+  var sortedWords = sortByOccurence(wordMap);
+  console.log(sortedWords);
+  var topWords = selectTopWords(sortedWords, 5);
+  console.log(topWords);
+}
+
+function removeKeyWords(keepArray,toRemoveArray){
+  keepArray = keepArray.filter( function( el ) {
+    return toRemoveArray.indexOf( el ) < 0;
+  } );
+  return keepArray;
+}
+
+function groupByOccurence(arr){
+    if(arr.length == 0)
+    return null;
+  var modeMap = {};
+  var maxEl = arr[0], maxCount = 1;
+  for(var i = 0; i < arr.length; i++)
+  {
+    var el = arr[i];
+    if(modeMap[el] == null)
+      modeMap[el] = 1;
+    else
+      modeMap[el]++;  
+  }
+    return modeMap;
+}
+
+function sortByOccurence(obj){
+  var sortable = [];
+  for (var word in obj)
+    sortable.push([word, obj[word]])
+    sortable.sort(function(a, b) {
+      return b[1] - a[1];
+    })
+  return sortable;
+}
+
+function selectTopWords(arr, n){
+  var topWords = [];
+  for(var i = 0 ; i < n; i++){
+    topWords.push(arr[i])
+  }
+  return topWords
+}
+
+
+wordCount(body);


### PR DESCRIPTION
Working code:
- Display of N most occurring words in text with a filter on common words such as 'and' , 'I', etc.
- Display of donut chart with hard-coded data

To do:
- Connect donut chart to JSON object from sentiment API-call
- Scale donut chart to panel-dimensions

@venture-vin @UmarFBajwa @raysapida @snehabn 
